### PR TITLE
16930. 달리기

### DIFF
--- a/Platinum/boj_16930_Running/Main.java
+++ b/Platinum/boj_16930_Running/Main.java
@@ -1,0 +1,95 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int n, m, k;
+	static char[][] map;
+	static int[][] visited;
+	static int[] dx = { -1, 1, 0, 0 };
+	static int[] dy = { 0, 0, -1, 1 };
+
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		k = Integer.parseInt(st.nextToken());
+		
+		map = new char[n + 1][m + 1];
+		for(int i = 1; i <= n; i++) {
+			String s = br.readLine();
+			for(int j = 1; j <= m; j++) {
+				map[i][j] = s.charAt(j - 1);
+			}
+		}
+		
+		st = new StringTokenizer(br.readLine());
+		int sx = Integer.parseInt(st.nextToken());
+		int sy = Integer.parseInt(st.nextToken());
+		int ex = Integer.parseInt(st.nextToken());
+		int ey = Integer.parseInt(st.nextToken());
+		
+		visited = new int[n + 1][m + 1];
+		for(int i = 1; i <= n; i++) {
+			Arrays.fill(visited[i], -1);
+		}
+		
+		System.out.println(bfs(sx, sy, ex, ey));
+
+	}
+	
+	public static int bfs(int x, int y, int ex, int ey) {
+		ArrayDeque<int[]> q = new ArrayDeque<>();
+		
+		q.offer(new int[] { x, y });
+		visited[x][y] = 0;
+		
+		while(!q.isEmpty()) {
+			int[] cur = q.poll();
+			int curX = cur[0];
+			int curY = cur[1];
+			
+			if(curX == ex && curY == ey) {
+				return visited[curX][curY];
+			}
+			
+			for(int i = 0; i < 4; i++) {
+				for(int s = 1; s <= k; s++) {
+					int nx = curX + dx[i] * s;
+					int ny = curY + dy[i] * s;
+					
+					if(nx < 1 || ny < 1 || nx > n || ny > m) {
+						break;
+					}
+					
+					if(map[nx][ny] == '#') {
+						break;
+					}
+					
+					// 이미 적은 값을 가지고 있으면 굳이 갱신할 필요 없으므로 break
+					if(visited[nx][ny] != -1 && visited[nx][ny] < visited[curX][curY] + 1) {
+						break;
+					}
+					
+					// 이미 방문한 칸이면 건너뛰고 다음 지점으로 이동
+					if(visited[nx][ny] == visited[curX][curY] + 1) {
+						continue;
+					}
+					
+					q.offer(new int[] { nx, ny });
+					visited[nx][ny] = visited[curX][curY] + 1;
+				}	
+			}
+		}
+		
+		return -1;
+	}
+
+}


### PR DESCRIPTION
## 문제/핵심 로직
- **상태 표현**: `visited[x][y]`에 **최소 이동 횟수(레벨)** 저장  
  - 초기값 `-1` = 미방문, 그 외 = 시작점에서의 최소 이동 횟수
- **이동 규칙 (상/하/좌/우)**  
  - 한 번의 이동에서 **같은 방향으로 최대 `k`칸까지** 전진 가능  
  - 벽이나 경계에 부딪히면 그 방향 확장 **중단**

---

## 구현 방법
- **BFS (큐)로 최단거리 탐색**
  - 큐 원소: `{x, y}`
  - 루프 절차:
    1. **도착점 조기 종료**  
       꺼낸 좌표가 `(ex, ey)`면 즉시 `visited[curX][curY]` 반환
    2. **4방향 확장 with 최대 `k`칸 직진**
       - 매 방향에 대해 `s = 1..k`로 **직선 확장**
       - **가지치기 조건** (아래 순서대로 평가)
         - **경계 밖**이면 `break` (더 멀리는 모두 불가능)
         - **벽**이면 `break`
         - `visited[nx][ny] != -1` **AND**  
           `visited[nx][ny] < visited[curX][curY] + 1`이면 `break`  
           → 이미 **더 짧은 비용으로 방문된 칸**을 만난 경우, 그 뒤 칸도 이득 없음
         - `visited[nx][ny] == visited[curX][curY] + 1`이면 `continue`  
           → **동일 비용으로 큐잉된 칸**은 중복 방지 (다음 `s`로 진행)
       - 위를 모두 통과하면  
         `visited[nx][ny] = visited[curX][curY] + 1;` 후 **enqueue**

---