### PR TITLE
15486. 퇴사2

### DIFF
--- a/Essential/boj_15486_Resignation2/Main.java
+++ b/Essential/boj_15486_Resignation2/Main.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int n;
+	static int[] time, pay, dp;
+
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+				
+		n = Integer.parseInt(br.readLine());
+		
+		time = new int[n + 1];
+		pay = new int[n + 1];
+		
+		for(int i = 1; i <= n; i++) {
+			st = new StringTokenizer(br.readLine());
+			time[i] = Integer.parseInt(st.nextToken());
+			pay[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		dp = new int[n + 2];
+		for(int i = n; i > 0; i--) {
+			int next = i + time[i];
+			
+			if(next <= n + 1) {
+				dp[i] = Math.max(dp[i + 1], pay[i] + dp[next]);
+			} else {
+				dp[i] = dp[i + 1];
+			}
+		}
+
+		System.out.println(dp[1]);
+		
+	}
+
+}


### PR DESCRIPTION
### 문제 요약
- 규칙 : `i`일부터 시작한 상담은 `time[i]`일 소요, 퇴사일은 `n + 1`이므로 `i + time[i] <= n`인 상담만 수행 가능하다.
---
### 핵심 로직
- `next = i + time[i]`가 `n + 1`보다 작거나 같으면 `max(dp[i + 1], pay[i] + dp[next])`, 퇴사일인 `n + 1`보다 크게 되면 `dp[i + 1]`
- 역순으로 채우고 `n + 1`도 접근해야하니 배열의 크기는 `n + 2`
---
### 여담
- 역순이 아닌 증가하는 방향으로도 접근해보고 싶으나 구현이 아직 부족하여 실패..ㅠ