### PR TITLE
boj_2533_SNS

### DIFF
--- a/Essential/boj_2533_SNS/Main.java
+++ b/Essential/boj_2533_SNS/Main.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static int n;
+    static ArrayList<Integer>[] list;
+    static boolean[] matched;
+    static int matchCnt = 0;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+
+        list = new ArrayList[n + 1];
+        for (int i = 1; i <= n; i++) {
+            list[i] = new ArrayList<>();
+        }
+
+        // 간선은 n-1개
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            list[u].add(v);
+            list[v].add(u);
+        }
+
+        matched = new boolean[n + 1];
+
+        dfs(1, 0);
+
+        System.out.println(matchCnt);
+    }
+
+    public static void dfs(int u, int point) {
+        for (int v : list[u]) {
+            if (v == point) {
+            	continue;
+            }
+            dfs(v, u);
+        }
+
+        for (int v : list[u]) {
+            if (v == point) {
+            	continue;
+            }
+            if (!matched[u] && !matched[v]) {
+                matched[u] = matched[v] = true;
+                matchCnt++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 요약
- 트리에서 각 간선은 양 끝점 중 최소 하나가 얼리어답터여야 한다.
- 목표: **얼리어답터 수의 최솟값**을 구하기.
- 트리의 성질을 이용하면 **최소 정점 커버 크기 = 최대 매칭 크기**가 성립한다.
- 따라서 정답은  
  얼리어답터 최소 수 = `matchCnt`  
---
## 핵심 로직
- DFS 후위순회
  - 자식 노드를 탐색한 다음 돌아옴
- 그리디 매칭
  - 부모 u와 자식 v가 둘 다 아직 매칭되지 않았다면 (u, v)를 매칭.
  - 매칭된 노드는 다시 다른 매칭에 쓰이지 않음.
- 최소 얼리어답터 수 계산
  - matchCnt = 최소 얼리어답터 수

