### PR TITLE
11437. LCA

### DIFF
--- a/Essential/boj_11437_LCA/Main.java
+++ b/Essential/boj_11437_LCA/Main.java
@@ -1,0 +1,85 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int n, m;
+	static ArrayList<Integer>[] list;
+	static int[] parent, depth;
+	static boolean[] visited;
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		
+		n = Integer.parseInt(br.readLine());
+		
+		list = new ArrayList[n + 1];
+		for(int i = 1; i <= n; i++) {
+			list[i] = new ArrayList<>();
+		}
+		
+		for(int i = 0; i < n - 1; i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			list[from].add(to);
+			list[to].add(from);
+		}
+		
+		parent = new int[n + 1];
+		depth = new int[n + 1];
+		visited = new boolean[n + 1];
+		dfs(1, 0);
+		
+		m = Integer.parseInt(br.readLine());
+		for(int i = 0; i < m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			sb.append(lca(from, to)).append("\n");
+		}
+		
+		System.out.println(sb);
+		
+	}
+	
+	public static void dfs(int node, int d) {
+		visited[node] = true;
+		depth[node] = d;
+		
+		for(int next : list[node]) {
+			if(visited[next]) continue;
+			
+			parent[next] = node;
+			dfs(next, d + 1);
+		}
+	}
+	
+	public static int lca(int from, int to) {
+		if(depth[from] < depth[to]) {
+			int tmp = from;
+			from = to;
+			to = tmp;
+		}
+		
+		while(depth[from] != depth[to]) {
+			from = parent[from];
+		}
+		
+		while(from != to) {
+			from = parent[from];
+			to = parent[to];
+		}
+		
+		return from;
+	}
+	
+}


### PR DESCRIPTION
## 핵심 전략
- 전처리 : DFS로 `parent`, `depth` 계산
  - 방문한 자식 정점 `next`에 대해서 아래를 수행
    - `parent[next] = node`
    - `dpeth[next[ = depth[node] + 1`
  - 이로써 모든 정점의 부모와 깊이를 한 번에 계산
- LCA 로직
  - 깊이 정렬
    - `from`과 `to` 중 깊이가 더 큰 정점을 `from`으로 맞춤
  - 깊이 맞추기
    - 두 정점의 깊이가 같아질 떄까지 더 깊은 정점을 `parent`로 올림
  - 동시에 승급
    - 깊이가 깊어진 뒤, `from == to`가 될 떄까지 두 정점을 동시에 부모로 승급