### PR TITLE
18808. 스티커 붙이기

### DIFF
--- a/Essential/boj_18808_AttachingSticker/Main.java
+++ b/Essential/boj_18808_AttachingSticker/Main.java
@@ -1,0 +1,104 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int n, m, k;
+	static int[][] map;
+	
+    public static void main(String[] args) throws Exception {
+    	
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        map = new int[n][m];
+        
+        for(int s = 0; s < k; s++) {
+        	st = new StringTokenizer(br.readLine());
+        	int r = Integer.parseInt(st.nextToken());
+        	int c = Integer.parseInt(st.nextToken());
+        	
+        	int [][] sticker = new int[r][c];
+        	for(int i = 0; i < r; i++) {
+        		st = new StringTokenizer(br.readLine());
+        		for(int j = 0; j < c; j++) {
+        			sticker[i][j] = Integer.parseInt(st.nextToken());
+        		}
+        	}
+        	
+        	boolean flag = false;
+        	for(int d = 0; d < 4 && !flag; d++) {
+        		int sr = r;
+        		int sc = c;
+        		
+        		for(int i = 0; i <= n - sr && !flag; i++) {
+        			for(int j = 0; j <= m - sc && !flag; j++) {
+        				if(attachable(sticker, i, j)) {
+        					attach(sticker, i, j);
+        					flag = true;
+        				}
+        			}
+        		}
+        		
+        		if(!flag) sticker = rotate(sticker);
+        	}
+        }
+        
+        int result = 0;
+        for(int i = 0; i < n; i++) {
+        	for(int j = 0; j < m; j++) {
+        		result += map[i][j];
+        	}
+        }
+        
+        System.out.println(result);
+        
+    }
+    
+    public static int[][] rotate(int[][] input) {
+    	int r = input.length;
+    	int c = input[0].length;
+    	
+    	int[][] output = new int[c][r];
+    	for(int i = 0; i < r; i++) {
+    		for(int j = 0; j < c; j++) {
+    			output[j][r - i - 1] = input[i][j];
+    		}
+    	}
+    	
+    	return output;
+    }
+    
+    public static boolean attachable(int[][] sticker, int sr, int sc) {
+    	int r = sticker.length;
+    	int c = sticker[0].length;
+    	
+    	for(int i = 0; i < r; i++) {
+    		for(int j = 0; j < c; j++) {
+    			if(sticker[i][j] == 1) {
+    				if(map[sr + i][sc + j] == 1) return false;
+    			}
+    		}
+    	}
+    	
+    	return true;
+    }
+    
+    public static void attach(int[][] sticker, int sr, int sc) {
+    	int r = sticker.length;
+    	int c = sticker[0].length;
+    	
+    	for(int i = 0; i < r; i++) {
+    		for(int j = 0; j < c; j++) {
+    			if(sticker[i][j] == 1) map[sr + i][sc + j] = 1;
+    		}
+    	}
+    }
+    
+}

--- a/Essential/boj_18808_AttachingSticker/Main.java
+++ b/Essential/boj_18808_AttachingSticker/Main.java
@@ -13,9 +13,9 @@ public class Main {
         StringTokenizer st = new StringTokenizer(br.readLine());
         StringBuilder sb = new StringBuilder();
         
-        int n = Integer.parseInt(st.nextToken());
-        int m = Integer.parseInt(st.nextToken());
-        int k = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
         
         map = new int[n][m];
         


### PR DESCRIPTION
## 핵심 전략
### 그리디 + 완탐
- 스티커에 대해 아래를 수행
  - 회전 횟수 : `0 ~ 3`
  - 현재 회전 상태의 크기를 `sr x sc`라고 할 때, 시작 좌표 `(i, j)`를 아래의 범위로 순회
    - `0 <= i <= n - sr`, `0 <= j <= m - sc`
  - 위지 `)i, j)`에서 겹침 없이 부찯 가능한지 검사하고 가능하면 즉시 부착 후 다음 스티커로 넘어감
  - 붙이지 못했다면 스티커를 90도 시계 방향으로 회전함
- 모든 스티커를 처리한 뒤 `map`에서 1의 개수를 합산해 출력